### PR TITLE
FIX-3 refactor: rename Role enum constants to UPPER_CASE to follow Ja…

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="LearningManagementSystem" />
+      </profile>
+    </annotationProcessing>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="LearningManagementSystem" options="-parameters" />
+    </option>
+  </component>
+</project>

--- a/.idea/cu-fci-sme-lms.iml
+++ b/.idea/cu-fci-sme-lms.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/LearningManagementSystem-main/src/main/java" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/LearningManagementSystem-main/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="23" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/cu-fci-sme-lms.iml" filepath="$PROJECT_DIR$/.idea/cu-fci-sme-lms.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/controller/InstructorController.java
+++ b/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/controller/InstructorController.java
@@ -251,7 +251,7 @@ public class InstructorController {
     public ResponseEntity<List<Notification>> getAllNotifications(@RequestParam int instructorId) {
         //return notificationService.getAllNotifications(instructorId,Role.Instructor);
         try {
-            List<Notification> notifications = notificationService.getAllNotifications(instructorId, Role.Student);
+            List<Notification> notifications = notificationService.getAllNotifications(instructorId, Role.STUDENT);
             return ResponseEntity.ok(notifications);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Collections.emptyList());
@@ -261,7 +261,7 @@ public class InstructorController {
     public ResponseEntity<List<Notification>> getUnReadNotifications(@RequestParam int instructorId) {
         //return notificationService.getUnReadNotifications(instructorId,Role.Instructor);
         try {
-            List<Notification> notifications = notificationService.getUnReadNotifications(instructorId, Role.Student);
+            List<Notification> notifications = notificationService.getUnReadNotifications(instructorId, Role.STUDENT);
             return ResponseEntity.ok(notifications);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Collections.emptyList());

--- a/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/controller/StudentController.java
+++ b/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/controller/StudentController.java
@@ -68,25 +68,25 @@ public class StudentController {
 
                 // Send notification to the student for successful enrollment
                 String successMessageForStudent = "Enrollment successful for course: " + course.getCourseTitle();
-                notificationService.createNotification(student.getId(), Role.Student, successMessageForStudent);
+                notificationService.createNotification(student.getId(), Role.STUDENT, successMessageForStudent);
 
                 // Send notification to the instructor
                 Instructor instructor = course.getInstructor();
                 String successMessageForInstructor = "A student (" + student.getName() + ") has enrolled in your course: " + course.getCourseTitle();
-                notificationService.createNotification(instructor.getId(), Role.Instructor, successMessageForInstructor);
+                notificationService.createNotification(instructor.getId(), Role.INSTRUCTOR, successMessageForInstructor);
 
                 return successMessageForStudent;
             } else {
                 // Send notification to the student for failure (course not found)
                 String failureMessage = "Enrollment failed: Course not found.";
-                notificationService.createNotification(studentId, Role.Student, failureMessage);
+                notificationService.createNotification(studentId, Role.STUDENT, failureMessage);
 
                 return failureMessage;
             }
         } else {
             // Send notification for failure (student not found)
             String failureMessage = "Enrollment failed: Student not found.";
-            notificationService.createNotification(studentId,Role.Student, failureMessage);
+            notificationService.createNotification(studentId,Role.STUDENT, failureMessage);
 
             return failureMessage;
         }
@@ -161,7 +161,7 @@ public class StudentController {
     public ResponseEntity<List<Notification>> getAllNotifications(@RequestParam int studentId) {
         try {
             //return notificationService.getAllNotifications(studentId, Role.Student);
-            List<Notification> notifications = notificationService.getAllNotifications(studentId, Role.Student);
+            List<Notification> notifications = notificationService.getAllNotifications(studentId, Role.STUDENT);
             return ResponseEntity.ok(notifications);
         }catch (Exception e){
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Collections.emptyList());
@@ -171,7 +171,7 @@ public class StudentController {
     public ResponseEntity<List<Notification>> getUnReadNotifications(@RequestParam int studentId) {
         //return notificationService.getUnReadNotifications(studentId,Role.Student);
         try {
-            List<Notification> notifications = notificationService.getUnReadNotifications(studentId, Role.Student);
+            List<Notification> notifications = notificationService.getUnReadNotifications(studentId, Role.STUDENT);
             return ResponseEntity.ok(notifications);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Collections.emptyList());

--- a/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/model/Admin.java
+++ b/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/model/Admin.java
@@ -26,7 +26,7 @@ public class Admin extends User {
 
     public Admin(String name, String email, String password,Role role) {
         super( name, email, password);
-        this.role = Role.Admin;
+        this.role = Role.ADMIN;
     }
 
 

--- a/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/model/Instructor.java
+++ b/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/model/Instructor.java
@@ -24,7 +24,7 @@ public class Instructor extends User{
 
     public Instructor(String name, String email, String password,Role role) {
         super(name, email, password);
-        this.role = Role.Instructor;
+        this.role = Role.INSTRUCTOR;
     }
 
 

--- a/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/model/Role.java
+++ b/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/model/Role.java
@@ -1,7 +1,7 @@
 package LMS.LearningManagementSystem.model;
 
 public enum Role {
-    Student,
-    Instructor,
-    Admin
+    STUDENT,
+    INSTRUCTOR,
+    ADMIN
 }

--- a/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/model/Student.java
+++ b/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/model/Student.java
@@ -29,7 +29,7 @@ public class Student extends User {
 
     public Student(String name, String email, String password,Role role) {
         super(name, email, password);
-        this.role = Role.Student;
+        this.role = Role.STUDENT;
     }
 
     public void addCourse(Course course){                    // يجب التعديل بعد إضافة كلاس الكورس

--- a/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/service/AdminService.java
+++ b/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/service/AdminService.java
@@ -19,7 +19,7 @@ public class AdminService {
     }
 
     public void addStudent(String name, String email, String password) {
-        Student newStudent = new Student (name, email, password, Role.Student);
+        Student newStudent = new Student (name, email, password, Role.STUDENT);
         studentRepository.save(newStudent); // Save the student to the database
         System.out.println("Student Added Successfully");
     }

--- a/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/service/AssignmentService.java
+++ b/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/service/AssignmentService.java
@@ -110,7 +110,7 @@ public class AssignmentService {
         // Notify the student about the graded assignment
         String message = "Your assignment for course with ID : " + crs.getCourseTitle() +
                 " has been graded. Your grade is: " + grade + ".";
-        notificationService.createNotification(log.getStudentId(), Role.Student, message);
+        notificationService.createNotification(log.getStudentId(), Role.STUDENT, message);
     }
 
     private Integer extractStudentIdFromToken(String token) {

--- a/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/service/InstructorService.java
+++ b/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/service/InstructorService.java
@@ -60,7 +60,7 @@ public class InstructorService {
         String notification = quiz.getTitle() + "has been added to " + quiz.getCourse().getCourseTitle();
         List<Student> students = course.getEnrolledStudents();
         for(Student student : students){
-            notificationService.createNotification(student.getId(),Role.Student, notification);
+            notificationService.createNotification(student.getId(),Role.STUDENT, notification);
         }
     }
 

--- a/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/service/StudentService.java
+++ b/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/service/StudentService.java
@@ -73,7 +73,7 @@ public class StudentService {
         attempt.setAttemptDate(Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant()));
         String feedback = "Your score in " + quiz.getTitle() + " is " + score + " out of " + quiz.getTotalGrade() +
                 " in " + quiz.getCourse().getCourseTitle();
-        notificationService.createNotification(studentId, Role.Student, feedback);
+        notificationService.createNotification(studentId, Role.STUDENT, feedback);
         attempt.setFeedback(feedback);
         quizLogRepository.save(attempt);
 

--- a/LearningManagementSystem-main/src/test/java/LMS/LearningManagementSystem/AssignmentServiceTest.java
+++ b/LearningManagementSystem-main/src/test/java/LMS/LearningManagementSystem/AssignmentServiceTest.java
@@ -174,6 +174,6 @@ class AssignmentServiceTest {
         assertEquals(95, log.getGrade());
         verify(assignmentLogRepository, times(1)).save(log);
         verify(notificationService, times(1))
-                .createNotification(eq(2026), eq(Role.Student), contains("Your grade is: 95"));
+                .createNotification(eq(2026), eq(Role.STUDENT), contains("Your grade is: 95"));
     }
 }

--- a/LearningManagementSystem-main/src/test/java/LMS/LearningManagementSystem/NotificationServiceTest.java
+++ b/LearningManagementSystem-main/src/test/java/LMS/LearningManagementSystem/NotificationServiceTest.java
@@ -45,7 +45,7 @@ class NotificationServiceTest {
     void testGetUnReadNotifications() {
         // Arrange
         int userId = 1;
-        Role userType = Role.Student;
+        Role userType = Role.STUDENT;
         Notification notification = new Notification();
         notification.setUserId(userId);
         notification.setUserType(userType);
@@ -66,7 +66,7 @@ class NotificationServiceTest {
     void testGetAllNotifications() {
         // Arrange
         int userId = 1;
-        Role userType = Role.Student;
+        Role userType = Role.STUDENT;
         Notification notification1 = new Notification();
         notification1.setUserId(userId);
         notification1.setUserType(userType);
@@ -149,7 +149,7 @@ class NotificationServiceTest {
     void testCreateNotification() {
         // Arrange
         int userId = 1;
-        Role userType = Role.Student;
+        Role userType = Role.STUDENT;
         String message = "Your grade is: 95";
 
         // Create a student

--- a/LearningManagementSystem-main/src/test/java/LMS/LearningManagementSystem/StudentServiceTest.java
+++ b/LearningManagementSystem-main/src/test/java/LMS/LearningManagementSystem/StudentServiceTest.java
@@ -137,7 +137,7 @@ class StudentServiceTest {
         assertNotNull(feedback, "Feedback should not be null");
         assertTrue(feedback.contains("Your score"), "Feedback should contain score");
         verify(quizLogRepository, times(1)).save(quizLog);
-        verify(notificationService, times(1)).createNotification(anyInt(), eq(Role.Student), anyString());
+        verify(notificationService, times(1)).createNotification(anyInt(), eq(Role.STUDENT), anyString());
     }
 
     @Test


### PR DESCRIPTION
refactor: rename Role enum constants to UPPER_CASE to follow Java naming conventions

Renamed enum values in Role.java from Instructor → INSTRUCTOR and Admin → ADMIN
to match Java and project naming standards (^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$).
Updated all references across the codebase accordingly.