### PR TITLE
FIX-5-empty-method-implementation-in-course-java-violates-sonar-qube-rule-java-s-1186

### DIFF
--- a/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/model/Course.java
+++ b/LearningManagementSystem-main/src/main/java/LMS/LearningManagementSystem/model/Course.java
@@ -75,9 +75,5 @@ public class Course {
         enrolledStudents.add(student);
     }
 
-    public void setMediaFiles(ArrayList<Object> objects) {
-    }
-
-    public void setId(Integer courseId) {
-    }
+    
 }


### PR DESCRIPTION
removed repeated setters in Course.java as they get autogenerated by supported spring boot annotations